### PR TITLE
Move typescript types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
   },
   "homepage": "https://github.com/expo/expo-server-sdk-node#readme",
   "dependencies": {
-    "@types/invariant": "^2.2.29",
-    "@types/node-fetch": "^2.1.4",
     "node-fetch": "^2.3.0",
     "promise-limit": "^2.7.0"
   },
   "devDependencies": {
+    "@types/invariant": "^2.2.29",
     "@types/jest": "^23.3.10",
+    "@types/node-fetch": "^2.1.4",
     "jest": "^23.6.0",
     "ts-jest": "^23.10.5",
     "typescript": "^3.2.1"


### PR DESCRIPTION
These are not required at runtime, typechecking stuff should be in devDependencies