### PR TITLE
Update push ticket type to match documentation

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -299,7 +299,8 @@ export type ExpoPushMessage = {
 
 export type ExpoPushReceiptId = string;
 
-export type ExpoPushTicket = {
+type ExpoPushSuccessTicket = {
+  status: 'ok';
   id: ExpoPushReceiptId;
 };
 
@@ -319,6 +320,10 @@ type ExpoPushErrorReceipt = {
   // Internal field used only by developers working on Expo
   __debug?: any;
 };
+
+type ExpoPushErrorTicket = ExpoPushErrorReceipt;
+
+export type ExpoPushTicket = ExpoPushSuccessTicket | ExpoPushErrorTicket;
 
 export type ExpoPushReceipt = ExpoPushSuccessReceipt | ExpoPushErrorReceipt;
 


### PR DESCRIPTION
According to the [documentation](https://docs.expo.io/versions/latest/guides/push-notifications/#response-format), a **Push Ticket** has both an id and status field:

> Upon success, the HTTP response will be a JSON object whose data field is an array of push tickets, each of which corresponds to the message at its respective index in the request. Continuing the above example, this is what a successful response body looks like:
> 
> ```
> {
>   "data": [
>     {"status": "ok", "id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"},
>     {"status": "ok", "id": "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY}
>   ]
> }
> ```

However, right now `ExpoPushTicket` only has an `id` field, so typescript throws an error (`Property 'status' does not exist on type 'ExpoPushTicket'.`) if you try to check the status. This PR fixes that.

I found the documentation a little hard to follow\*, so I'm not *sure* that these changes are totally correct, so feel free to implement your own fix or give me feedback to I can change it to be correct, if this isn't merge-able.

\*but that's not the point of this issue.