### PR TITLE
Add apns-push-type to `ExpoPushMessage`

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -351,6 +351,7 @@ export type ExpoPushMessage = {
   priority?: 'default' | 'normal' | 'high';
   badge?: number;
   channelId?: string;
+  'apns-push-type'?: 'alert' | 'background';
 };
 
 export type ExpoPushReceiptId = string;


### PR DESCRIPTION
Starting with iOS 13 (releasing today) this key is required for messages to iOS devices.

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns