### PR TITLE
Add missed parameters for `ExpoPushMessage`

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -351,7 +351,7 @@ export type ExpoPushMessage = {
   priority?: 'default' | 'normal' | 'high';
   badge?: number;
   channelId?: string;
-  icon?: string
+  icon?: string;
   _category?: string;
   _displayInForeground?: boolean;
 };

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -351,6 +351,7 @@ export type ExpoPushMessage = {
   priority?: 'default' | 'normal' | 'high';
   badge?: number;
   channelId?: string;
+  icon?: string
   _category?: string;
   _displayInForeground?: boolean;
 };

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -351,6 +351,8 @@ export type ExpoPushMessage = {
   priority?: 'default' | 'normal' | 'high';
   badge?: number;
   channelId?: string;
+  _category?: string;
+  _displayInForeground?: boolean;
 };
 
 export type ExpoPushReceiptId = string;


### PR DESCRIPTION
According to docs https://docs.expo.io/versions/v35.0.0/guides/push-notifications/#message-format we can pass as well `_category` and `_displayInForeground` props