### PR TITLE
Update isExpoPushToken type signature

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -51,7 +51,7 @@ export class Expo {
   /**
    * Returns `true` if the token is an Expo push token
    */
-  static isExpoPushToken(token: any): token is ExpoPushToken {
+  static isExpoPushToken(token: unknown): token is ExpoPushToken {
     return (
       typeof token === 'string' &&
       (((token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')) &&

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -51,7 +51,7 @@ export class Expo {
   /**
    * Returns `true` if the token is an Expo push token
    */
-  static isExpoPushToken(token: ExpoPushToken): boolean {
+  static isExpoPushToken(token: any): token is ExpoPushToken {
     return (
       typeof token === 'string' &&
       (((token.startsWith('ExponentPushToken[') || token.startsWith('ExpoPushToken[')) &&


### PR DESCRIPTION
I think this is a better fit for what the function actually does: we don't know the type of the thing coming in, but we do know the type if it returns true.

https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates

note: I did this in GitHub's web interface so I didn't test if it compiles, although it *should* (famous last words)