### PR TITLE
fix: add missing error type and fault field

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -402,7 +402,8 @@ export type ExpoPushErrorReceipt = {
   status: 'error';
   message: string;
   details?: {
-    error?: 'DeviceNotRegistered' | 'InvalidCredentials' | 'MessageTooBig' | 'MessageRateExceeded';
+    error?: 'DeviceNotRegistered' | 'InvalidCredentials' | 'MessageTooBig' | 'MessageRateExceeded' | 'ExpoError';
+    fault?: 'expo';
   };
   // Internal field used only by developers working on Expo
   __debug?: any;


### PR DESCRIPTION
We've received the following error numerous times in our app. It seems this error code is undocumented and untyped, so this PR just adds it to the ticket error type.

If any expo employees are aware of a complete list of types and fault codes, I would appreciate it if you could share. This part of the ecosystem seems incomplete; for example, the push notification documentation only mentions a [single error code](https://docs.expo.dev/push-notifications/sending-notifications/#push-ticket-errors).