### PR TITLE
Added support for FCM V1 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import { Expo } from 'expo-server-sdk';
 // optionally providing an access token if you have enabled push security
 let expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
-  useFCMv1: false // this can be set to true in order to use the FCM v1 API
+  useFcmV1: false // this can be set to true in order to use the FCM v1 API
 });
 
 // Create the messages that you want to send to clients

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ import { Expo } from 'expo-server-sdk';
 
 // Create a new Expo SDK client
 // optionally providing an access token if you have enabled push security
-let expo = new Expo({ accessToken: process.env.EXPO_ACCESS_TOKEN });
+let expo = new Expo({
+  accessToken: process.env.EXPO_ACCESS_TOKEN,
+  useFCM: false // this can be set to true in order to use the FCM v1 API
+});
 
 // Create the messages that you want to send to clients
 let messages = [];

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import { Expo } from 'expo-server-sdk';
 // optionally providing an access token if you have enabled push security
 let expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
-  useFCM: false // this can be set to true in order to use the FCM v1 API
+  useFCMv1: false // this can be set to true in order to use the FCM v1 API
 });
 
 // Create the messages that you want to send to clients

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -77,8 +77,11 @@ export class Expo {
    * sized chunks.
    */
   async sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]> {
+    // @ts-expect-error We don't yet have type declarations for URL
     const url = new URL(`${BASE_API_URL}/push/send`);
-    if (this.useFcmV1) url.searchParams.append('useFcmV1', 'true');
+    if (typeof this.useFcmV1 === 'boolean') {
+      url.searchParams.append('useFcmV1', this.useFcmV1);
+    }
     const actualMessagesCount = Expo._getActualMessageCount(messages);
     const data = await this.limitConcurrentRequests(async () => {
       return await promiseRetry(

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -40,7 +40,7 @@ export class Expo {
   private httpAgent: Agent | undefined;
   private limitConcurrentRequests: <T>(thunk: () => Promise<T>) => Promise<T>;
   private accessToken: string | undefined;
-  private useFCM: boolean | undefined;
+  private useFCMv1: boolean | undefined;
   
   constructor(options: ExpoClientOptions = {}) {
     this.httpAgent = options.httpAgent;
@@ -50,7 +50,7 @@ export class Expo {
         : DEFAULT_CONCURRENT_REQUEST_LIMIT
     );
     this.accessToken = options.accessToken;
-    this.useFCM = options.useFCM;
+    this.useFCMv1 = options.useFCMv1;
   }
 
   /**
@@ -77,13 +77,13 @@ export class Expo {
    * sized chunks.
    */
   async sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]> {
-    const useFCM = this.useFCM ? '?useFcmV1=true' : '';
+    const useFCMv1 = this.useFCMv1 ? '?useFcmV1=true' : '';
     const actualMessagesCount = Expo._getActualMessageCount(messages);
     const data = await this.limitConcurrentRequests(async () => {
       return await promiseRetry(
         async (retry): Promise<any> => {
           try {
-            return await this.requestAsync(`${BASE_API_URL}/push/send${useFCM}`, {
+            return await this.requestAsync(`${BASE_API_URL}/push/send${useFCMv1}`, {
               httpMethod: 'post',
               body: messages,
               shouldCompress(body) {
@@ -355,7 +355,7 @@ export type ExpoClientOptions = {
   httpAgent?: Agent;
   maxConcurrentRequests?: number;
   accessToken?: string;
-  useFCM?: boolean;
+  useFCMv1?: boolean;
 };
 
 export type ExpoPushToken = string;

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -40,8 +40,8 @@ export class Expo {
   private httpAgent: Agent | undefined;
   private limitConcurrentRequests: <T>(thunk: () => Promise<T>) => Promise<T>;
   private accessToken: string | undefined;
-  private useFCMv1: boolean | undefined;
-  
+  private useFcmV1: boolean | undefined;
+
   constructor(options: ExpoClientOptions = {}) {
     this.httpAgent = options.httpAgent;
     this.limitConcurrentRequests = promiseLimit(
@@ -50,7 +50,7 @@ export class Expo {
         : DEFAULT_CONCURRENT_REQUEST_LIMIT
     );
     this.accessToken = options.accessToken;
-    this.useFCMv1 = options.useFCMv1;
+    this.useFcmV1 = options.useFcmV1;
   }
 
   /**
@@ -77,13 +77,14 @@ export class Expo {
    * sized chunks.
    */
   async sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]> {
-    const useFCMv1 = this.useFCMv1 ? '?useFcmV1=true' : '';
+    const url = new URL(`${BASE_API_URL}/push/send`);
+    if (this.useFcmV1) url.searchParams.append('useFcmV1', 'true');
     const actualMessagesCount = Expo._getActualMessageCount(messages);
     const data = await this.limitConcurrentRequests(async () => {
       return await promiseRetry(
         async (retry): Promise<any> => {
           try {
-            return await this.requestAsync(`${BASE_API_URL}/push/send${useFCMv1}`, {
+            return await this.requestAsync(url.toString(), {
               httpMethod: 'post',
               body: messages,
               shouldCompress(body) {
@@ -355,7 +356,7 @@ export type ExpoClientOptions = {
   httpAgent?: Agent;
   maxConcurrentRequests?: number;
   accessToken?: string;
-  useFCMv1?: boolean;
+  useFcmV1?: boolean;
 };
 
 export type ExpoPushToken = string;

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -40,7 +40,8 @@ export class Expo {
   private httpAgent: Agent | undefined;
   private limitConcurrentRequests: <T>(thunk: () => Promise<T>) => Promise<T>;
   private accessToken: string | undefined;
-
+  private useFCM: boolean | undefined;
+  
   constructor(options: ExpoClientOptions = {}) {
     this.httpAgent = options.httpAgent;
     this.limitConcurrentRequests = promiseLimit(
@@ -49,6 +50,7 @@ export class Expo {
         : DEFAULT_CONCURRENT_REQUEST_LIMIT
     );
     this.accessToken = options.accessToken;
+    this.useFCM = options.useFCM;
   }
 
   /**
@@ -75,13 +77,13 @@ export class Expo {
    * sized chunks.
    */
   async sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]> {
+    const useFCM = this.useFCM ? '?useFcmV1=true' : '';
     const actualMessagesCount = Expo._getActualMessageCount(messages);
-
     const data = await this.limitConcurrentRequests(async () => {
       return await promiseRetry(
         async (retry): Promise<any> => {
           try {
-            return await this.requestAsync(`${BASE_API_URL}/push/send`, {
+            return await this.requestAsync(`${BASE_API_URL}/push/send${useFCM}`, {
               httpMethod: 'post',
               body: messages,
               shouldCompress(body) {
@@ -353,6 +355,7 @@ export type ExpoClientOptions = {
   httpAgent?: Agent;
   maxConcurrentRequests?: number;
   accessToken?: string;
+  useFCM?: boolean;
 };
 
 export type ExpoPushToken = string;

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -49,6 +49,34 @@ describe('sending push notification messages', () => {
     expect(options.headers.get('Authorization')).toContain('Bearer foobar');
   });
 
+  describe('the useFcmV1 option', () => {
+    beforeEach(() => {
+      (fetch as any).any({ data: [{ status: 'ok', id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' }] });
+    });
+
+    test('sends requests to the Expo API server without the useFcmV1 parameter', async () => {
+      const client = new ExpoClient();
+      await client.sendPushNotificationsAsync([{ to: 'a' }]);
+      expect((fetch as any).called('https://exp.host/--/api/v2/push/send')).toBe(true);
+    });
+
+    test('sends requests to the Expo API server with useFcmV1=true', async () => {
+      const client = new ExpoClient({ useFcmV1: true });
+      await client.sendPushNotificationsAsync([{ to: 'a' }]);
+      expect((fetch as any).called('https://exp.host/--/api/v2/push/send?useFcmV1=true')).toBe(
+        true
+      );
+    });
+
+    test('sends requests to the Expo API server with useFcmV1=false', async () => {
+      const client = new ExpoClient({ useFcmV1: false });
+      await client.sendPushNotificationsAsync([{ to: 'a' }]);
+      expect((fetch as any).called('https://exp.host/--/api/v2/push/send?useFcmV1=false')).toBe(
+        true
+      );
+    });
+  });
+
   test('compresses request bodies over 1 KiB', async () => {
     const mockTickets = [{ status: 'ok', id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' }];
     (fetch as any).mock('https://exp.host/--/api/v2/push/send', { data: mockTickets });


### PR DESCRIPTION
Based on this FCM related blogpost here, [https://expo.dev/blog/expo-adds-support-for-fcm-http-v1-api](url) it seems like there's no solution for people like us who use the Node SDK to send push notifications.

This change adds support for initiating `ExpoClient` with another optional parameter called `useFCM: true` which appends the necessary query string to the `/push/send` (?useFcmV1=true)