### PR TITLE
Remove useFcmV1 Due to Upcoming Legacy API Deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ import { Expo } from 'expo-server-sdk';
 // optionally providing an access token if you have enabled push security
 let expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
-  useFcmV1: false // this can be set to true in order to use the FCM v1 API
 });
 
 // Create the messages that you want to send to clients

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -41,7 +41,6 @@ export class Expo {
   private httpAgent: Agent | undefined;
   private limitConcurrentRequests: <T>(thunk: () => Promise<T>) => Promise<T>;
   private accessToken: string | undefined;
-  private useFcmV1: boolean | undefined;
 
   constructor(options: ExpoClientOptions = {}) {
     this.httpAgent = options.httpAgent;
@@ -51,7 +50,6 @@ export class Expo {
         : DEFAULT_CONCURRENT_REQUEST_LIMIT,
     );
     this.accessToken = options.accessToken;
-    this.useFcmV1 = options.useFcmV1;
   }
 
   /**
@@ -79,9 +77,6 @@ export class Expo {
    */
   async sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]> {
     const url = new URL(`${BASE_API_URL}/push/send`);
-    if (typeof this.useFcmV1 === 'boolean') {
-      url.searchParams.append('useFcmV1', String(this.useFcmV1));
-    }
     const actualMessagesCount = Expo._getActualMessageCount(messages);
     const data = await this.limitConcurrentRequests(async () => {
       return await promiseRetry(
@@ -359,7 +354,6 @@ export type ExpoClientOptions = {
   httpAgent?: Agent;
   maxConcurrentRequests?: number;
   accessToken?: string;
-  useFcmV1?: boolean;
 };
 
 export type ExpoPushToken = string;

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -49,34 +49,6 @@ describe('sending push notification messages', () => {
     expect(options.headers.get('Authorization')).toContain('Bearer foobar');
   });
 
-  describe('the useFcmV1 option', () => {
-    beforeEach(() => {
-      (fetch as any).any({ data: [{ status: 'ok', id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' }] });
-    });
-
-    test('sends requests to the Expo API server without the useFcmV1 parameter', async () => {
-      const client = new ExpoClient();
-      await client.sendPushNotificationsAsync([{ to: 'a' }]);
-      expect((fetch as any).called('https://exp.host/--/api/v2/push/send')).toBe(true);
-    });
-
-    test('sends requests to the Expo API server with useFcmV1=true', async () => {
-      const client = new ExpoClient({ useFcmV1: true });
-      await client.sendPushNotificationsAsync([{ to: 'a' }]);
-      expect((fetch as any).called('https://exp.host/--/api/v2/push/send?useFcmV1=true')).toBe(
-        true,
-      );
-    });
-
-    test('sends requests to the Expo API server with useFcmV1=false', async () => {
-      const client = new ExpoClient({ useFcmV1: false });
-      await client.sendPushNotificationsAsync([{ to: 'a' }]);
-      expect((fetch as any).called('https://exp.host/--/api/v2/push/send?useFcmV1=false')).toBe(
-        true,
-      );
-    });
-  });
-
   test('compresses request bodies over 1 KiB', async () => {
     const mockTickets = [{ status: 'ok', id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' }];
     (fetch as any).mock('https://exp.host/--/api/v2/push/send', { data: mockTickets });


### PR DESCRIPTION
We don't need the useFcmV1 because the legacy API won't be available after June 20, 2024.
https://expo.dev/blog/expo-adds-support-for-fcm-http-v1-api#fcm-timeline