### PR TITLE
Add expoPushToken to ExpoPushErrorReceipt type

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -418,6 +418,7 @@ export type ExpoPushErrorReceipt = {
       | 'MessageTooBig'
       | 'ProviderError';
   };
+  expoPushToken?: string;
   // Internal field used only by developers working on Expo
   __debug?: any;
 };


### PR DESCRIPTION
When an error is generated by Expo attempting to send a push notification, it includes the `expoPushToken` in the result depending on the type of error. It is included for type `DeviceNotRegistered` where it is important to know what token failed so it can be removed from the user, especially if a given user has multiple tokens associated.