### PR TITLE
fix: useFcmV1 should default to true and be deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ import { Expo } from 'expo-server-sdk';
 // optionally providing an access token if you have enabled push security
 let expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
-  useFcmV1: false // this can be set to true in order to use the FCM v1 API
+  /*
+   * @deprecated
+   * The optional useFcmV1 parameter defaults to true, as FCMv1 is now the default for the Expo push service.
+   *
+   * If using FCMv1, the useFcmV1 parameter may be omitted.
+   * Set this to false to have Expo send to the legacy endpoint.
+   *
+   * See https://firebase.google.com/support/faq#deprecated-api-shutdown
+   * for important information on the legacy endpoint shutdown.
+   *
+   * Once the legacy service is fully shut down, the parameter will be removed in a future PR.
+   */
+  useFcmV1: true,
 });
 
 // Create the messages that you want to send to clients

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -66,7 +66,8 @@ export class Expo {
    */
   async sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]> {
     const url = new URL(sendApiUrl);
-    if (typeof this.useFcmV1 === 'boolean') {
+    // Only append the useFcmV1 option if the option is set to false
+    if (this.useFcmV1 === false) {
       url.searchParams.append('useFcmV1', String(this.useFcmV1));
     }
     const actualMessagesCount = Expo._getActualMessageCount(messages);

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -69,7 +69,8 @@ describe('sending push notification messages', () => {
     test('sends requests to the Expo API server with useFcmV1=true', async () => {
       const client = new ExpoClient({ useFcmV1: true });
       await client.sendPushNotificationsAsync([{ to: 'a' }]);
-      expect((fetch as any).called(`${sendApiUrl}?useFcmV1=true`)).toBe(true);
+      // Request should omit useFcmV1 if set to true
+      expect((fetch as any).called(`${sendApiUrl}`)).toBe(true);
     });
 
     test('sends requests to the Expo API server with useFcmV1=false', async () => {


### PR DESCRIPTION
`useFcmV1` defaults to true to align with push service change:

- Will not be added to the URL unless it is set to `false`
- Update `README.md` with comments on the change
- Update unit test