### PR TITLE
Remove values mock from test

### DIFF
--- a/src/ExpoClientValues.ts
+++ b/src/ExpoClientValues.ts
@@ -30,4 +30,4 @@ export const defaultConcurrentRequestLimit = 6;
 /**
  * Minimum timeout in ms for request retries.
  */
-export const requestRetryMinTimeout = 1000;
+export const requestRetryMinTimeout = process.env['NODE_ENV'] === 'test' ? 1 : 1000;

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -1,18 +1,9 @@
-import { jest, afterEach, beforeEach, describe, test, expect } from '@jest/globals';
+import { afterEach, beforeEach, describe, test, expect } from '@jest/globals';
 import fetch from 'node-fetch';
 import assert from 'node:assert';
 
 import ExpoClient, { ExpoPushMessage } from '../ExpoClient';
 import { getReceiptsApiUrl, sendApiUrl } from '../ExpoClientValues';
-
-jest.mock('../ExpoClientValues', () => ({
-  requestRetryMinTimeout: 1,
-  pushNotificationChunkLimit: 100,
-  sendApiUrl: 'http://localhost:3000/--/api/v2/push/send',
-  getReceiptsApiUrl: 'http://localhost:3000/--/api/v2/push/getReceipts',
-  pushNotificationReceiptChunkLimit: 300,
-  defaultConcurrentRequestLimit: 6,
-}));
 
 afterEach(() => {
   (fetch as any).reset();


### PR DESCRIPTION
It's easy for this mock to fall out of sync with the actual module, and solutions which would prevent this would be verbose and cluttered.  The only thing it achieves is keeping the tests fast with a lower retry timeout, and that can also be achieved with a switch on `NODE_ENV`.
