### PR TITLE
100% test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
   },
   "jest": {
     "coverageDirectory": "<rootDir>/../coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 0
+      }
+    },
     "preset": "ts-jest",
     "rootDir": "src",
     "testEnvironment": "node"

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -29,14 +29,14 @@ export class Expo {
   private limitConcurrentRequests: <T>(thunk: () => Promise<T>) => Promise<T>;
   private accessToken: string | undefined;
   private useFcmV1: boolean | undefined;
+  private retryMinTimeout: number;
 
-  constructor(options: ExpoClientOptions = {}) {
+  constructor(options: Partial<ExpoClientOptions> = {}) {
     this.httpAgent = options.httpAgent;
     this.limitConcurrentRequests = promiseLimit(
-      options.maxConcurrentRequests != null
-        ? options.maxConcurrentRequests
-        : defaultConcurrentRequestLimit,
+      options.maxConcurrentRequests ?? defaultConcurrentRequestLimit,
     );
+    this.retryMinTimeout = options.retryMinTimeout ?? requestRetryMinTimeout;
     this.accessToken = options.accessToken;
     this.useFcmV1 = options.useFcmV1;
   }
@@ -93,7 +93,7 @@ export class Expo {
         {
           retries: 2,
           factor: 2,
-          minTimeout: requestRetryMinTimeout,
+          minTimeout: this.retryMinTimeout,
         },
       );
     });
@@ -334,10 +334,11 @@ export class Expo {
 export default Expo;
 
 export type ExpoClientOptions = {
-  httpAgent?: Agent;
-  maxConcurrentRequests?: number;
-  accessToken?: string;
-  useFcmV1?: boolean;
+  httpAgent: Agent;
+  maxConcurrentRequests: number;
+  retryMinTimeout: number;
+  accessToken: string;
+  useFcmV1: boolean;
 };
 
 export type ExpoPushToken = string;

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -8,7 +8,7 @@
 import fetch, { Headers, Response as FetchResponse } from 'node-fetch';
 import assert from 'node:assert';
 import { Agent } from 'node:http';
-import zlib from 'node:zlib';
+import { gzipSync } from 'node:zlib';
 import promiseLimit from 'promise-limit';
 import promiseRetry from 'promise-retry';
 
@@ -218,7 +218,7 @@ export class Expo {
       const json = JSON.stringify(options.body);
       assert(json != null, `JSON request body must not be null`);
       if (options.shouldCompress(json)) {
-        requestBody = await gzipAsync(Buffer.from(json));
+        requestBody = gzipSync(Buffer.from(json));
         requestHeaders.set('Content-Encoding', 'gzip');
       } else {
         requestBody = json;
@@ -332,18 +332,6 @@ export class Expo {
 }
 
 export default Expo;
-
-function gzipAsync(data: Buffer): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    zlib.gzip(data, (error, result) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(result);
-      }
-    });
-  });
-}
 
 export type ExpoClientOptions = {
   httpAgent?: Agent;

--- a/src/ExpoClientValues.ts
+++ b/src/ExpoClientValues.ts
@@ -30,4 +30,4 @@ export const defaultConcurrentRequestLimit = 6;
 /**
  * Minimum timeout in ms for request retries.
  */
-export const requestRetryMinTimeout = process.env['NODE_ENV'] === 'test' ? 1 : 1000;
+export const requestRetryMinTimeout = 1000;

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -213,7 +213,7 @@ describe('sending push notification messages', () => {
       { repeat: 3 },
     );
 
-    const client = new ExpoClient();
+    const client = new ExpoClient({ retryMinTimeout: 1 });
     const ticketPromise = client.sendPushNotificationsAsync([]);
 
     const rejection = expect(ticketPromise).rejects;
@@ -241,7 +241,7 @@ describe('sending push notification messages', () => {
       )
       .mock(sendApiUrl, { data: mockTickets }, { overwriteRoutes: false });
 
-    const client = new ExpoClient();
+    const client = new ExpoClient({ retryMinTimeout: 1 });
     await expect(client.sendPushNotificationsAsync([{ to: 'a' }, { to: 'b' }])).resolves.toEqual(
       mockTickets,
     );

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "./build",
     "rootDir": "./src"
   },
-  "exclude": ["node_modules", "**/__mocks__", "**/__tests__", "build"]
+  "exclude": ["node_modules", "**/__mocks__", "**/__tests__", "build", "coverage"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "composite": true,
     "noEmit": true
   },
-  "exclude": ["build"]
+  "exclude": ["build", "coverage"]
 }


### PR DESCRIPTION
I noticed that with the codecov action broken, coverage had dropped without us noticing (#88), but not very far.  It was easy to bring it back and add a threshold to keep it there. 
