### PR TITLE
Remove fetch-mock

### DIFF
--- a/src/__mocks__/node-fetch.ts
+++ b/src/__mocks__/node-fetch.ts
@@ -1,1 +1,0 @@
-module.exports = require('fetch-mock').sandbox();


### PR DESCRIPTION
Using jest to mock at the boundaries of node-fetch directly is simpler, and makes type mismatches between the mock and the real module less likely.
