### PR TITLE
feat: support interruptionLevel for iOS

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -361,6 +361,7 @@ export type ExpoPushMessage = {
   ttl?: number;
   expiration?: number;
   priority?: 'default' | 'normal' | 'high';
+  interruptionLevel?: 'active' | 'critical' | 'passive' | 'time-sensitive';
   badge?: number;
   channelId?: string;
   categoryId?: string;


### PR DESCRIPTION
the push service now supports the `interruptionLevel` field: see https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Payload-key-reference