### PR TITLE
feat: support custom sounds

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -351,11 +351,11 @@ export type ExpoPushMessage = {
   subtitle?: string;
   body?: string;
   sound?:
-    | 'default'
+    | string
     | null
     | {
         critical?: boolean;
-        name?: 'default' | null;
+        name?: string | null;
         volume?: number;
       };
   ttl?: number;


### PR DESCRIPTION
### Usage

This is for iOS only. Android sounds are specified via `channelId` [docs](https://docs.expo.dev/versions/latest/sdk/notifications/#handling-notification-channels).

When you configure a sound in our config plugin ([docs.expo.dev/versions/latest/sdk/notifications#configurable-properties](https://docs.expo.dev/versions/latest/sdk/notifications/#configurable-properties)) you can then refer the sound in the `sound` field.

example: 

```
sound: 'bells_sound.wav',
```

If an invalid sound file (one that doesn't exist in the application bundle on the device) is specified in payload to Expo Push, default is played instead. Keep in mind sounds aren't played in silent mode or focus modes that may be set by user.