### PR TITLE
Run tests on Pull Requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,7 @@
 name: Tests
 on: 
   push:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we require the checks before merging, this is necessary.  Since we can [approve workflow runs from contributors](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks), it is also safe.