### PR TITLE
Fix Invalid URL error when using expo-server-sdk inside API Routes

### DIFF
--- a/src/ExpoClientValues.ts
+++ b/src/ExpoClientValues.ts
@@ -4,7 +4,7 @@
  * The EXPO_BASE_URL environment variable is only for internal Expo use
  * when testing the push service locally.
  */
-const baseUrl = process.env['EXPO_BASE_URL'] ?? 'https://exp.host';
+const baseUrl = process.env['EXPO_BASE_URL'] || 'https://exp.host';
 
 export const sendApiUrl = `${baseUrl}/--/api/v2/push/send`;
 


### PR DESCRIPTION
I am using expo-server-sdk in an Expo project inside the API Routes. 

When calling `expo.sendPushNotificationsAsync([message]);` I get an error `code: 'ERR_INVALID_URL',  input: '/--/api/v2/push/send'`

I investigated and the problem seems to come from `process.env['EXPO_BASE_URL']` being empty string instead of undefined. 

I understand that this might be related to my local setup, but I checked and I don't set the EXPO_BASE_URL env anywhere. 

Not exactly sure, but maybe the issue comes from Expo Router API Routes and how env variables are treated there?

Anyway, the suggested fix solves the issue by using the default base url, when the environment var is missing or is empty string.