### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,8 @@ import { Expo } from 'expo-server-sdk';
 
 // Create a new Expo SDK client
 // optionally providing an access token if you have enabled push security
-let expo = new Expo({
+const expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
-  /*
-   * @deprecated
-   * The optional useFcmV1 parameter defaults to true, as FCMv1 is now the default for the Expo push service.
-   *
-   * If using FCMv1, the useFcmV1 parameter may be omitted.
-   * Set this to false to have Expo send to the legacy endpoint.
-   *
-   * See https://firebase.google.com/support/faq#deprecated-api-shutdown
-   * for important information on the legacy endpoint shutdown.
-   *
-   * Once the legacy service is fully shut down, the parameter will be removed in a future PR.
-   */
-  useFcmV1: true,
 });
 
 // Create the messages that you want to send to clients
@@ -59,86 +46,79 @@ for (let pushToken of somePushTokens) {
 // recommend you batch your notifications to reduce the number of requests
 // and to compress them (notifications with similar content will get
 // compressed).
-let chunks = expo.chunkPushNotifications(messages);
+const chunks = expo.chunkPushNotifications(messages);
 let tickets = [];
-(async () => {
-  // Send the chunks to the Expo push notification service. There are
-  // different strategies you could use. A simple one is to send one chunk at a
-  // time, which nicely spreads the load out over time:
-  for (let chunk of chunks) {
-    try {
-      let ticketChunk = await expo.sendPushNotificationsAsync(chunk);
-      console.log(ticketChunk);
-      tickets.push(...ticketChunk);
-      // NOTE: If a ticket contains an error code in ticket.details.error, you
-      // must handle it appropriately. The error codes are listed in the Expo
-      // documentation:
-      // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
-    } catch (error) {
-      console.error(error);
-    }
-  }
-})();
-
-...
-
-// Later, after the Expo push notification service has delivered the
-// notifications to Apple or Google (usually quickly, but allow the service
-// up to 30 minutes when under load), a "receipt" for each notification is
-// created. The receipts will be available for at least a day; stale receipts
-// are deleted.
-//
-// The ID of each receipt is sent back in the response "ticket" for each
-// notification. In summary, sending a notification produces a ticket, which
-// contains a receipt ID you later use to get the receipt.
-//
-// The receipts may contain error codes to which you must respond. In
-// particular, Apple or Google may block apps that continue to send
-// notifications to devices that have blocked notifications or have uninstalled
-// your app. Expo does not control this policy and sends back the feedback from
-// Apple and Google so you can handle it appropriately.
-let receiptIds = [];
-for (let ticket of tickets) {
-  // NOTE: Not all tickets have IDs; for example, tickets for notifications
-  // that could not be enqueued will have error information and no receipt ID.
-   if (ticket.status === 'ok') {
-    receiptIds.push(ticket.id);
+// Send the chunks to the Expo push notification service. There are
+// different strategies you could use. A simple one is to send one chunk at a
+// time, which nicely spreads the load out over time:
+for (let chunk of chunks) {
+  try {
+    let ticketChunk = await expo.sendPushNotificationsAsync(chunk);
+    console.log(ticketChunk);
+    tickets.push(...ticketChunk);
+    // NOTE: If a ticket contains an error code in ticket.details.error, you
+    // must handle it appropriately. The error codes are listed in the Expo
+    // documentation:
+    // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
+  } catch (error) {
+    console.error(error);
   }
 }
 
-let receiptIdChunks = expo.chunkPushNotificationReceiptIds(receiptIds);
-(async () => {
-  // Like sending notifications, there are different strategies you could use
-  // to retrieve batches of receipts from the Expo service.
-  for (let chunk of receiptIdChunks) {
-    try {
-      let receipts = await expo.getPushNotificationReceiptsAsync(chunk);
-      console.log(receipts);
+```
 
-      // The receipts specify whether Apple or Google successfully received the
-      // notification and information about an error, if one occurred.
-      for (let receiptId in receipts) {
-        let { status, message, details } = receipts[receiptId];
-        if (status === 'ok') {
-          continue;
-        } else if (status === 'error') {
-          console.error(
-            `There was an error sending a notification: ${message}`
-          );
-          if (details && details.error) {
-            // The error codes are listed in the Expo documentation:
-            // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
-            // You must handle the errors appropriately.
-            console.error(`The error code is ${details.error}`);
-          }
+Later, after the Expo push notification service has delivered the
+notifications to Apple or Google (usually quickly, but allow the service
+up to 30 minutes when under load), a "receipt" for each notification is
+created. The receipts will be available for at least a day; stale receipts
+are deleted.
+
+The ID of each receipt is sent back in the response "ticket" for each
+notification. In summary, sending a notification produces a ticket, which
+contains a receipt ID you later use to get the receipt.
+
+The receipts may contain error codes to which you must respond. In
+particular, Apple or Google may block apps that continue to send
+notifications to devices that have blocked notifications or have uninstalled
+your app. Expo does not control this policy and sends back the feedback from
+Apple and Google so you can handle it appropriately.
+
+```js
+// NOTE: Not all tickets have IDs; for example, tickets for notifications
+// that could not be enqueued will have error information and no receipt ID.
+const receiptIds = tickets.filter(ticket => ticket.status === 'ok').map(ticket => ticket.id);
+
+const receiptIdChunks = expo.chunkPushNotificationReceiptIds(receiptIds);
+
+// Like sending notifications, there are different strategies you could use
+// to retrieve batches of receipts from the Expo service.
+for (let chunk of receiptIdChunks) {
+  try {
+    const receipts = await expo.getPushNotificationReceiptsAsync(chunk);
+    console.log(receipts);
+
+    // The receipts specify whether Apple or Google successfully received the
+    // notification and information about an error, if one occurred.
+    for (const receiptId in receipts) {
+      const { status, message, details } = receipts[receiptId];
+      if (status === 'ok') {
+        continue;
+      } else if (status === 'error') {
+        console.error(
+          `There was an error sending a notification: ${message}`
+        );
+        if (details && details.error) {
+          // The error codes are listed in the Expo documentation:
+          // https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
+          // You must handle the errors appropriately.
+          console.error(`The error code is ${details.error}`);
         }
       }
-    } catch (error) {
-      console.error(error);
     }
+  } catch (error) {
+    console.error(error);
   }
-})();
-
+}
 ```
 
 ## Developing


### PR DESCRIPTION
this makes the readme a little more digestable

- removes old `useFcmV1` parameter
- removes immediately invoked function expressions from the readme, they make the code harder to read an anybody can figure out for themselves how they will structure their code


### Test plan:

- TODO