### PR TITLE
chore: skip ci on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
         id: release
         with:
           release-type: node
+          pull-request-title-pattern: 'chore${scope}: release${component} ${version} [skip ci]'
       # The logic below handles the npm publication:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         # these if statements ensure that a publication only occurs when


### PR DESCRIPTION
To hopefully resolve a deadlock where https://github.com/expo/expo-server-sdk-node/pull/159 doesn't run required CI checks because the PR was opened by a GH action afaict. (https://github.com/googleapis/release-please/issues/922)

we could run the checks, but it's imo good enough to skip them