### PR TITLE
chore: skip ci on release pt2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
         id: release
         with:
           release-type: node
-          pull-request-title-pattern: 'chore${scope}: release${component} ${version} [skip ci]'
       # The logic below handles the npm publication:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         # these if statements ensure that a publication only occurs when

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {}
+  },
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version} [skip ci]"
+}


### PR DESCRIPTION
same as https://github.com/expo/expo-server-sdk-node/pull/160 but after reading the docs better