### PR TITLE
chore: skip ci on release pt4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4
         id: release
-        with:
-          release-type: node
       # The logic below handles the npm publication:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         # these if statements ensure that a publication only occurs when

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,5 +3,6 @@
   "packages": {
     ".": {}
   },
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version} [skip ci]"
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version} [skip ci]",
+  "release-type": "node"
 }


### PR DESCRIPTION
reading  https://github.com/googleapis/release-please-action#basic-configuration

> Specifying a release-type configuration is the most straight-forward configuration option, but allows for no further customization.

_sigh_